### PR TITLE
docs: add Spanish README

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,21 @@
+# zxl19.github.io
+
+```text
+Todos saben del valor útil de las cosas, pero nadie entiende el valor de lo inútil.
+```
+
+## Historial de estrellas
+
+<p align="center">
+    <a href="https://www.star-history.com/#">
+        <picture>
+            <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=zxl19/zxl19.github.io&type=date&theme=dark&legend=top-left">
+            <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=zxl19/zxl19.github.io&type=date&legend=top-left">
+            <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=zxl19/zxl19.github.io&type=date&legend=top-left" width="75%">
+        </picture>
+    </a>
+</p>
+
+## Licencia
+
+<a href="https://zxl19.github.io">zxl19.github.io</a> © 2020 por <a href="https://github.com/zxl19">zxl19</a> está licenciado bajo <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">


### PR DESCRIPTION
Adds README.es-ES.md alongside the original documentation.

Generated by `poolside/laguna-xs-2.1:free` via OpenRouter.